### PR TITLE
Don't use deprecated functions

### DIFF
--- a/lib/geolix/adapter/fake.ex
+++ b/lib/geolix/adapter/fake.ex
@@ -39,9 +39,7 @@ defmodule Geolix.Adapter.Fake do
 
   @impl Geolix.Adapter
   def database_workers(_database) do
-    import Supervisor.Spec
-
-    [worker(Storage, [])]
+    [Storage.child_spec(%{})]
   end
 
   @impl Geolix.Adapter

--- a/lib/geolix/database/supervisor.ex
+++ b/lib/geolix/database/supervisor.ex
@@ -9,7 +9,7 @@ defmodule Geolix.Database.Supervisor do
   end
 
   @doc false
-  def init(_default), do: supervise([], strategy: :one_for_all)
+  def init(_default), do: Supervisor.init([], strategy: :one_for_all)
 
   @doc """
   Starts the worker processes of a database if not already under supervision.

--- a/test/geolix/database/loader_test.exs
+++ b/test/geolix/database/loader_test.exs
@@ -7,15 +7,15 @@ defmodule Geolix.Database.LoaderTest do
     @behaviour Geolix.Adapter
 
     defmodule LifecycleStorage do
-      def start_link, do: Agent.start_link(fn -> %{} end, name: __MODULE__)
+      use Agent
+
+      def start_link(_state), do: Agent.start_link(fn -> %{} end, name: __MODULE__)
       def get(action), do: Agent.get(__MODULE__, &Map.get(&1, action))
       def set(action, id), do: Agent.update(__MODULE__, &Map.put(&1, action, id))
     end
 
     def database_workers(_database) do
-      import Supervisor.Spec
-
-      [worker(LifecycleStorage, [])]
+      [LifecycleStorage.child_spec(%{})]
     end
 
     def load_database(%{id: id}), do: LifecycleStorage.set(:load_database, id)


### PR DESCRIPTION
This commit will remove the usage of deprecated functions:
* Supervisor.Spec.worker/2
* Supervisor.Spec.supervise/2

Signed-off-by: Slawomir Stepien <sst@poczta.fm>